### PR TITLE
Fixed compilation on GOARCH=386

### DIFF
--- a/pkg/winregistry/winregistry.go
+++ b/pkg/winregistry/winregistry.go
@@ -382,7 +382,7 @@ func (w WinregRegistry) getLhHash(key string) uint32 {
 		res += int(b)
 	}
 
-	return uint32(res % 0x100000000)
+	return uint32(int64(res) % 0x100000000)
 }
 
 type reg_hash struct {


### PR DESCRIPTION
This is a small fixe to remove the following error ` ../../../go/pkg/mod/github.com/!c-!sto/gosecretsdump@v0.3.0/pkg/winregistry/winregistry.go:385:20: constant 4294967296 overflows int` while building using `GOARCH=386` `GOOS=windows`